### PR TITLE
fix(Image): exclude component images from viewer

### DIFF
--- a/src/components/common/LmImage.vue
+++ b/src/components/common/LmImage.vue
@@ -46,6 +46,7 @@ const onError = (e: Event): void => {
       loading="lazy"
       aria-hidden="true"
       alt=""
+      data-no-viewer
       v-bind="{ ...resAttrs, ...$attrs }"
       @error="onError"
     />
@@ -58,6 +59,7 @@ const onError = (e: Event): void => {
       loading="lazy"
       aria-hidden="true"
       alt=""
+      data-no-viewer
       v-bind="{ ...resAttrs, ...$attrs }"
       @error="onError"
     />
@@ -71,6 +73,7 @@ const onError = (e: Event): void => {
       loading="lazy"
       aria-hidden="true"
       alt=""
+      data-no-viewer
       v-bind="typeof image === 'string' ? $attrs : { ...resAttrs, ...$attrs }"
       @error="onError"
     />


### PR DESCRIPTION
excluding Images for [vitepress-plugin-image-viewer](https://www.npmjs.com/package/vitepress-plugin-image-viewer)

Use the following method to exclude images from the plugin's preview:

```diff
+import { useRoute } from 'vitepress'
+import imageViewer from 'vitepress-plugin-image-viewer'
 import DefaultTheme from 'vitepress/theme'
+import 'viewerjs/dist/viewer.min.css'

 export default {
  extends: DefaultTheme,
+  setup() {
+    const route = useRoute()
+    imageViewer(route, '.vp-doc', {
+      filter: (img: HTMLImageElement) => !img.hasAttribute('data-no-viewer')
+    })
+  }
 }
