### PR TITLE
fix: align runtime and package requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "s-theo/lumen",
   "license": "MIT",
   "author": "Theo",
+  "engines": {
+    "node": ">=22.12.0 <23"
+  },
   "scripts": {
     "build": "pnpm -F=docs build",
     "change": "cd src && pnpm dlx changelogithub --dry",

--- a/src/composables/googleAnalytics.ts
+++ b/src/composables/googleAnalytics.ts
@@ -22,5 +22,5 @@ function mountGoogleAnalytics(id: string) {
   gtag('config', id)
 }
 export default ({ id }: { id: string }) => {
-  if (process.env.NODE_ENV === 'production' && id && typeof window !== 'undefined') mountGoogleAnalytics(id)
+  if (import.meta.env.PROD && id && typeof window !== 'undefined') mountGoogleAnalytics(id)
 }

--- a/src/composables/umamiAnalytics.ts
+++ b/src/composables/umamiAnalytics.ts
@@ -14,7 +14,7 @@ export type UmamiOption = Umami | Umami[]
 
 function mountUmami(options: UmamiOption) {
   // 确保只有在生产环境下执行
-  if (process.env.NODE_ENV !== 'production') {
+  if (!import.meta.env.PROD) {
     return
   }
 

--- a/src/package.json
+++ b/src/package.json
@@ -111,6 +111,10 @@
     "iconify-icon": "^3.0.2",
     "typescript": "^7.0.2"
   },
+  "peerDependencies": {
+    "vitepress": "^1.6.4 || >=2.0.0-alpha.18 <3.0.0",
+    "vue": "^3.5.0"
+  },
   "devDependencies": {
     "bumpp": "^11.1.0",
     "vitepress": "catalog:",

--- a/src/style/button.css
+++ b/src/style/button.css
@@ -20,7 +20,7 @@
   --vp-button-sponsor-hover-text: var(--lm-c-white-dark);
   --vp-button-sponsor-hover-bg: var(--vp-c-sponsor);
   --vp-button-sponsor-active-border: var(--vp-c-sponsor);
-  --vp-button-sponsor-active-text: var(--lm-c-black-dark);
+  --vp-button-sponsor-active-text: var(--lm-c-black-darker);
   --vp-button-sponsor-active-bg: var(--vp-c-sponsor);
 }
 

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -1,3 +1,11 @@
+interface ImportMetaEnv {
+  readonly PROD: boolean
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
 declare module '*.css' {
   const content: Record<string, string>
   export default content


### PR DESCRIPTION
## Summary

- use Vite's production flag for Google Analytics and Umami without requiring Node globals
- declare the Vue and VitePress peer dependency ranges used by the published package
- document the Node 22 minimum required by Vite 8
- correct the undefined sponsor active-text CSS variable

## Why

The standalone `src` TypeScript check failed because analytics code referenced `process` without Node types. The package also imported Vue and VitePress at runtime without declaring them as peers, and one button state referenced an undefined color variable.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `pnpm -C src exec tsc --noEmit -p tsconfig.json`
- `pnpm run build`
- `npm_config_cache=/tmp/lumen-npm-cache npm pack --dry-run --json` (40 expected files)
- `pnpm dlx publint@latest src` (no errors; existing metadata suggestions only)