### PR TITLE
fix(waline): honor custom comment path

### DIFF
--- a/src/components/LmWaline.vue
+++ b/src/components/LmWaline.vue
@@ -14,7 +14,7 @@ const { lang, isDark } = useData()
   <ClientOnly>
     <Waline
       :serverURL="data.serverURL"
-      :path="route.path"
+      :path="data.path ?? route.path"
       :lang="data.lang || lang"
       :locale="data.locale"
       :emoji="data.emoji"


### PR DESCRIPTION
## Summary

- use `Waline_Data.path` when a custom comment path is configured
- fall back to the current VitePress route when no override is provided

## Why

`WalineData.path` is part of the public type and the documentation says it can override the automatically detected route, but `LmWaline` always passed `route.path`. As a result, aliases, migrated pages, and pages intended to share a comment thread could not use the configured path.

## Validation

- `pnpm run format:check`
- `pnpm -C src exec tsc --noEmit -p tsconfig.json`
- `pnpm run build`