### PR TITLE
fix(image): honor crop prop

### DIFF
--- a/src/components/common/LmImage.vue
+++ b/src/components/common/LmImage.vue
@@ -14,7 +14,9 @@ defineOptions({ inheritAttrs: false })
 const isThemedImage = (image: ImageType): image is { light: string; dark: string } =>
   typeof image === 'object' && 'light' in image && 'dark' in image
 
-const shouldCrop = computed(() => Boolean(typeof props.image === 'object' && 'crop' in props.image && props.image.crop))
+const shouldCrop = computed(
+  () => props.crop || Boolean(typeof props.image === 'object' && 'crop' in props.image && props.image.crop)
+)
 
 const imageAttrs = computed(() => {
   if (typeof props.image === 'string') return {}


### PR DESCRIPTION
## Summary

- honor the top-level `crop` prop declared by `LmImage`
- preserve the existing `image.crop` behavior

## Problem

`LmImage` declared `crop?: boolean`, but its crop calculation only inspected `image.crop`. The component accepted the top-level prop without applying the `crop` class.

### Before

This documented component prop was accepted but did **not** crop the image:

```vue
<LmImage image="/banner.png" crop />
```

Only the nested image option worked:

```vue
<LmImage :image="{ src: '/banner.png', crop: true }" />
```

## After

Both supported inputs enable the same centered 1:1 crop:

```vue
<!-- Top-level prop now works -->
<LmImage image="/banner.png" crop />

<!-- Existing nested option remains supported -->
<LmImage :image="{ src: '/banner.png', crop: true }" />
```

Callers without either crop option keep the original image ratio. Existing callers that use `image.crop` are unchanged.

## Validation

- `pnpm run format:check`
- `pnpm -C src exec tsc --noEmit -p tsconfig.json`
- `pnpm run build`
- temporary browser comparison: default image rendered at 240×120; top-level `crop` rendered at 240×240 with centered cover; no Vite error overlay