### PR TITLE
build(package): declare side effect files

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -93,6 +93,10 @@
   "module": "./types/index.ts",
   "types": "./types/index.d.ts",
   "style": "./style/all.css",
+  "sideEffects": [
+    "./types/index.ts",
+    "**/*.css"
+  ],
   "files": [
     "style/",
     "types/",


### PR DESCRIPTION
## Summary

- declare the package runtime entry and CSS files as side-effectful
- allow bundlers to tree-shake other unused modules safely

## Before

The published package did not provide `sideEffects` metadata:

```json
{
  "style": "./style/all.css",
  "files": ["style/", "types/", "components/", "composables/"]
}
```

Bundlers therefore could not use package-level side-effect information for precise module pruning. Setting `sideEffects: false` would not be safe because the root runtime entry imports global CSS and registers `iconify-icon`.

## After

The package explicitly preserves only the known side-effectful files:

```json
{
  "sideEffects": [
    "./types/index.ts",
    "**/*.css"
  ]
}
```

- `./types/index.ts` preserves the global component variables and `iconify-icon` registration.
- `**/*.css` preserves direct style subpath imports.
- Vue component modules remain tree-shakeable and are retained when their exports are actually used.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `pnpm -C src exec tsc --noEmit -p tsconfig.json`
- `pnpm run build`
- `pnpm dlx publint@latest src` (the missing `sideEffects` suggestion is resolved)
- packed 40 expected files and installed the tarball in a clean temporary VitePress consumer
- consumer build with `@theojs/lumen/style`: full CSS retained
- consumer build without the full style import: root component variables and Iconify registration retained
- unused Waline component code and unrequested full Lumen styles were absent from the consumer bundle