### PR TITLE
refactor: tighten config types and dependency scope

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,7 +48,6 @@ export default defineConfig({
   // vite 配置
   vite: {
     plugins: [
-      // @ts-ignore: 使用 rolldown-vite 时类型不兼容 vite，但运行正常
       groupIconVitePlugin({
         customIcon: {
           按需导入: 'logos:typescript-icon',
@@ -59,7 +58,7 @@ export default defineConfig({
           '.vitepress': 'https://vitepress.dev/vitepress-logo-mini.svg',
           iconify: 'https://i.theojs.cn/logo/iconify.svg'
         }
-      }), // @ts-ignore
+      }),
       llmstxt({})
     ]
   },

--- a/docs/.vitepress/configs/transformPageData.ts
+++ b/docs/.vitepress/configs/transformPageData.ts
@@ -1,4 +1,4 @@
-import type { UserConfig } from 'vitepress'
+import type { HeadConfig, UserConfig } from 'vitepress'
 
 const baseUrl = 'https://lumen.theojs.cn'
 const imgUrl = 'https://i.theojs.cn/logo/lumen-logo-large.svg'
@@ -6,7 +6,7 @@ const defaultOgImage = 'https://i.theojs.cn/logo/Lumen-og.webp'
 
 export const transformPageData: UserConfig['transformPageData'] = (pageData) => {
   // head is an array
-  pageData.frontmatter.head ??= []
+  const head = (pageData.frontmatter.head ??= []) as HeadConfig[]
 
   // canonical URL
   const DynamicUrl = `${baseUrl}/${pageData.relativePath}`.replace(/index\.md$/, '').replace(/\.md$/, '')
@@ -21,9 +21,7 @@ export const transformPageData: UserConfig['transformPageData'] = (pageData) => 
   const modified_time = pageData.lastUpdated ? new Date(pageData.lastUpdated).toISOString() : new Date().toISOString()
 
   // og:image
-  const ogImageEntry = pageData.frontmatter.head.find(
-    (item: any) => item[0] === 'meta' && item[1]?.property === 'og:image'
-  )
+  const ogImageEntry = head.find((item) => item[0] === 'meta' && item[1]?.property === 'og:image')
   const ogImage = ogImageEntry?.[1]?.content || defaultOgImage
 
   // json-ld
@@ -61,7 +59,7 @@ export const transformPageData: UserConfig['transformPageData'] = (pageData) => 
       }
 
   // add head
-  pageData.frontmatter.head.push(
+  head.push(
     ['link', { rel: 'canonical', href: DynamicUrl }],
     ['meta', { property: 'og:title', content: title }],
     ['meta', { property: 'og:url', content: DynamicUrl }],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,13 +65,13 @@ importers:
       iconify-icon:
         specifier: ^3.0.2
         version: 3.0.2
-      typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
     devDependencies:
       bumpp:
         specifier: ^11.1.0
         version: 11.1.0
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
       vitepress:
         specifier: 'catalog:'
         version: 2.0.0-alpha.18(jiti@2.7.0)(postcss@8.5.17)(typescript@7.0.2)(yaml@2.9.0)

--- a/src/package.json
+++ b/src/package.json
@@ -112,8 +112,7 @@
   "dependencies": {
     "@iconify/vue": "^5.0.1",
     "@waline/client": "^3.15.2",
-    "iconify-icon": "^3.0.2",
-    "typescript": "^7.0.2"
+    "iconify-icon": "^3.0.2"
   },
   "peerDependencies": {
     "vitepress": "^1.6.4 || >=2.0.0-alpha.18 <3.0.0",
@@ -121,6 +120,7 @@
   },
   "devDependencies": {
     "bumpp": "^11.1.0",
+    "typescript": "^7.0.2",
     "vitepress": "catalog:",
     "vue": "catalog:"
   },


### PR DESCRIPTION
## Summary

- remove two stale `@ts-ignore` suppressions from the VitePress plugin configuration now that the current plugin types are compatible
- type page head entries with VitePress `HeadConfig` instead of `any`
- move `typescript` from runtime dependencies to dev dependencies without changing its version

## Before

```ts
// @ts-ignore: 使用 rolldown-vite...
groupIconVitePlugin(...)
...
const ogImageEntry = pageData.frontmatter.head.find(
  (item: any) => item[0] === 'meta' && item[1]?.property === 'og:image'
)
```

```json
"dependencies": {
  "typescript": "^7.0.2"
}
```

## After

```ts
groupIconVitePlugin(...)
...
const head = (pageData.frontmatter.head ??= []) as HeadConfig[]
const ogImageEntry = head.find(
  (item) => item[0] === 'meta' && item[1]?.property === 'og:image'
)
```

```json
"devDependencies": {
  "typescript": "^7.0.2"
}
```

The lockfile only reflects the dependency category change. This PR does not change runtime behavior, public APIs, page output, deployment settings, or dependency versions.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `pnpm -C src exec tsc --noEmit -p tsconfig.json`
- focused direct TypeScript check for the Vite plugin configuration and `transformPageData`
- `pnpm run build`
- `pnpm dlx publint@latest src` (passes; only the pre-existing repository URL suggestion remains)
- packed the 40-file package and built a clean VitePress consumer without TypeScript installed as a direct/runtime dependency
