### PR TITLE
chore(biome): align config schema version

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

- align the Biome configuration schema URL with the installed `@biomejs/biome` 2.5.4 CLI
- remove the schema-version mismatch info emitted by `pnpm run format:check`
- keep all formatter, assist, linter, and language rules unchanged

## Before

```json
{
  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json"
}
```

Running Biome 2.5.4 reported that the configuration schema still targeted 2.5.3.

## After

```json
{
  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json"
}
```

This is a configuration metadata correction only. It does not change runtime behavior, formatting rules, dependencies, page output, or deployment settings.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run format:check` (passes with the schema mismatch info removed)
- `pnpm run build`
- `git diff --check`
